### PR TITLE
D-33867 revert bad change (it had unintended side-effect)

### DIFF
--- a/src/osgEarthUtil/EarthManipulator.cpp
+++ b/src/osgEarthUtil/EarthManipulator.cpp
@@ -2173,7 +2173,9 @@ void EarthManipulator::recalculateCenter(const osg::CoordinateFrame &frame) {
 
 void EarthManipulator::pan(double dx, double dy) {
   if (!isTethering()) {
-    // D-33867 Avoid recalculateCenterFromLookVector to prevent abrupt zoom discontinuities
+    // to pan, we need a focus point on the terrain:
+    if (!recalculateCenterFromLookVector())
+      return;
 
     double scale = -0.3f * _distance;
 
@@ -2295,7 +2297,10 @@ void EarthManipulator::rotate(double dx, double dy) {
 }
 
 void EarthManipulator::zoom(double dx, double dy) {
-  // D-33867 Avoid recalculateCenterFromLookVector to prevent abrupt zoom discontinuities
+  // in normal (non-tethered mode) we need a valid zoom point.
+  if (!isTethering()) {
+    recalculateCenterFromLookVector();
+  }
 
   double scale = 1.0f + dy;
   setDistance(_distance * scale);


### PR DESCRIPTION
I had two parts of the workaround. 

The earliest part worked OK for the part of the problem it fixed.  It was simply putting a minimum zoom value in EnRouteLayerComponent for the terrain layer (12000 meters), so when the terrain layer was enabled, the view zoomed out to 12000 meters.  Then if the user zoomed in again, he would not see the black AMM layer any more.

The problem is when adding the second part (preventing the recalculation of the look vector).  This was done because we still had discontinuous jumps in zoom when disabling terrain.  This worked for that purpose, but I didn't realize until Friday that it broke the first part.  With the combined code, if the user enables terrain while zoomed in on SKRG:
-  the user sees black AMM for a split second, and then zooms out to 12000 meters, and AMM is no longer black (good)
- HOWEVER if the user then zooms manually back into SKRG, the AMM layer becomes black again